### PR TITLE
ScreenRender.javaのisPortraitの情報を外部から参照できるように変更

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/input/gl/render/ManagerRender.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/gl/render/ManagerRender.java
@@ -76,7 +76,9 @@ public class ManagerRender {
     screenRender.release();
   }
 
-  public boolean isPortrait() { return screenRender.isPortrait(); }
+  public boolean isPortrait() {
+    return screenRender.isPortrait();
+  }
 
   public void enableAA(boolean AAEnabled) {
     screenRender.setAAEnabled(AAEnabled);

--- a/encoder/src/main/java/com/pedro/encoder/input/gl/render/ManagerRender.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/gl/render/ManagerRender.java
@@ -76,7 +76,7 @@ public class ManagerRender {
     screenRender.release();
   }
 
-  public boolean isPortraitStart() {
+  public boolean isPortrait() {
     return screenRender.isPortrait();
   }
 

--- a/encoder/src/main/java/com/pedro/encoder/input/gl/render/ManagerRender.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/gl/render/ManagerRender.java
@@ -77,7 +77,7 @@ public class ManagerRender {
   }
 
   public boolean isPortraitStart() {
-    return screenRender.isPortrait;
+    return screenRender.isPortrait();
   }
 
   public void enableAA(boolean AAEnabled) {

--- a/encoder/src/main/java/com/pedro/encoder/input/gl/render/ManagerRender.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/gl/render/ManagerRender.java
@@ -76,9 +76,7 @@ public class ManagerRender {
     screenRender.release();
   }
 
-  public boolean isPortrait() {
-    return screenRender.isPortrait();
-  }
+  public boolean isPortrait() { return screenRender.isPortrait(); }
 
   public void enableAA(boolean AAEnabled) {
     screenRender.setAAEnabled(AAEnabled);

--- a/encoder/src/main/java/com/pedro/encoder/input/gl/render/ManagerRender.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/gl/render/ManagerRender.java
@@ -76,6 +76,10 @@ public class ManagerRender {
     screenRender.release();
   }
 
+  public boolean isPortraitStart() {
+    return screenRender.isPortrait;
+  }
+
   public void enableAA(boolean AAEnabled) {
     screenRender.setAAEnabled(AAEnabled);
   }

--- a/encoder/src/main/java/com/pedro/encoder/input/gl/render/ScreenRender.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/gl/render/ScreenRender.java
@@ -131,7 +131,9 @@ public class ScreenRender {
     return AAEnabled;
   }
 
-  public boolean isPortrait() { return isPortrait; }
+  public boolean isPortrait() {
+    return isPortrait;
+  }
 
   public void setStreamSize(int streamWidth, int streamHeight) {
     this.streamWidth = streamWidth;

--- a/encoder/src/main/java/com/pedro/encoder/input/gl/render/ScreenRender.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/gl/render/ScreenRender.java
@@ -48,7 +48,7 @@ public class ScreenRender {
 
   private int streamWidth;
   private int streamHeight;
-  public boolean isPortrait;
+  private boolean isPortrait;
 
   public ScreenRender() {
     squareVertex =
@@ -130,6 +130,8 @@ public class ScreenRender {
   public boolean isAAEnabled() {
     return AAEnabled;
   }
+
+  public boolean isPortrait() { return isPortrait; }
 
   public void setStreamSize(int streamWidth, int streamHeight) {
     this.streamWidth = streamWidth;

--- a/encoder/src/main/java/com/pedro/encoder/input/gl/render/ScreenRender.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/gl/render/ScreenRender.java
@@ -48,7 +48,7 @@ public class ScreenRender {
 
   private int streamWidth;
   private int streamHeight;
-  private boolean isPortrait;
+  public boolean isPortrait;
 
   public ScreenRender() {
     squareVertex =

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/GlInterface.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/GlInterface.java
@@ -128,5 +128,5 @@ public interface GlInterface {
    */
   void setForceRender(boolean force);
 
-  boolean isPortraitStart();
+  boolean isPortrait();
 }

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/GlInterface.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/GlInterface.java
@@ -127,4 +127,6 @@ public interface GlInterface {
    * Not recommendable in others modes.
    */
   void setForceRender(boolean force);
+
+  boolean isPortraitStart();
 }

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/LightOpenGlView.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/LightOpenGlView.java
@@ -150,7 +150,7 @@ public class LightOpenGlView extends OpenGlViewBase {
   }
 
   @Override
-  public boolean isPortraitStart() {
+  public boolean isPortrait() {
     return false;
   }
 }

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/LightOpenGlView.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/LightOpenGlView.java
@@ -150,7 +150,5 @@ public class LightOpenGlView extends OpenGlViewBase {
   }
 
   @Override
-  public boolean isPortrait() {
-    return false;
-  }
+  public boolean isPortrait() { return false; }
 }

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/LightOpenGlView.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/LightOpenGlView.java
@@ -148,4 +148,9 @@ public class LightOpenGlView extends OpenGlViewBase {
   public boolean isAAEnabled() {
     return false;
   }
+
+  @Override
+  public boolean isPortraitStart() {
+    return false;
+  }
 }

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/LightOpenGlView.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/LightOpenGlView.java
@@ -150,5 +150,7 @@ public class LightOpenGlView extends OpenGlViewBase {
   }
 
   @Override
-  public boolean isPortrait() { return false; }
+  public boolean isPortrait() {
+    return false;
+  }
 }

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OffScreenGlThread.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OffScreenGlThread.java
@@ -165,6 +165,11 @@ public class OffScreenGlThread
   }
 
   @Override
+  public boolean isPortraitStart() {
+    return textureManager.isPortraitStart();
+  }
+
+  @Override
   public void start() {
     synchronized (sync) {
       thread = new Thread(this);

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OffScreenGlThread.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OffScreenGlThread.java
@@ -165,7 +165,9 @@ public class OffScreenGlThread
   }
 
   @Override
-  public boolean isPortrait() { return textureManager.isPortrait(); }
+  public boolean isPortrait() {
+    return textureManager.isPortrait();
+  }
 
   @Override
   public void start() {

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OffScreenGlThread.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OffScreenGlThread.java
@@ -165,9 +165,7 @@ public class OffScreenGlThread
   }
 
   @Override
-  public boolean isPortrait() {
-    return textureManager.isPortrait();
-  }
+  public boolean isPortrait() { return textureManager.isPortrait(); }
 
   @Override
   public void start() {

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OffScreenGlThread.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OffScreenGlThread.java
@@ -165,8 +165,8 @@ public class OffScreenGlThread
   }
 
   @Override
-  public boolean isPortraitStart() {
-    return textureManager.isPortraitStart();
+  public boolean isPortrait() {
+    return textureManager.isPortrait();
   }
 
   @Override

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OpenGlView.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OpenGlView.java
@@ -105,7 +105,7 @@ public class OpenGlView extends OpenGlViewBase {
   }
 
   @Override
-  public boolean isPortraitStart() {
+  public boolean isPortrait() {
     return false;
   }
 

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OpenGlView.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OpenGlView.java
@@ -105,9 +105,7 @@ public class OpenGlView extends OpenGlViewBase {
   }
 
   @Override
-  public boolean isPortrait() {
-    return false;
-  }
+  public boolean isPortrait() { return false; }
 
   @Override
   public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OpenGlView.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OpenGlView.java
@@ -105,6 +105,11 @@ public class OpenGlView extends OpenGlViewBase {
   }
 
   @Override
+  public boolean isPortraitStart() {
+    return false;
+  }
+
+  @Override
   public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
     Log.i(TAG, "size: " + width + "x" + height);
     this.previewWidth = width;

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OpenGlView.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/view/OpenGlView.java
@@ -105,7 +105,9 @@ public class OpenGlView extends OpenGlViewBase {
   }
 
   @Override
-  public boolean isPortrait() { return false; }
+  public boolean isPortrait() {
+    return false;
+  }
 
   @Override
   public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {


### PR DESCRIPTION
## 概要  
配信開始時の端末方向情報を利用したいため、外部からも参照できるように変更する