### PR TITLE
#2695 画面に変化がないとストリームがとまる不具合

### DIFF
--- a/rtmp/src/main/java/net/ossrs/rtmp/SrsFlvMuxer.java
+++ b/rtmp/src/main/java/net/ossrs/rtmp/SrsFlvMuxer.java
@@ -252,15 +252,13 @@ public class SrsFlvMuxer {
 
     int dts = akamaiTs ? (int) ((System.nanoTime() / 1000 - startTs) / 1000) : frame.dts;
     if (frame.is_video()) {
-      publisher.publishVideoData(frame.flvTag.array(), frame.flvTag.size(), frame.dts);
+      publisher.publishVideoData(frame.flvTag.array(), frame.flvTag.size(), dts);
       if (frame.is_keyframe()) {
         Log.i(TAG, String.format("worker: send frame type=%d, dts=%d, size=%dB", frame.type, dts,
             frame.flvTag.array().length));
       } else {
         mVideoAllocator.release(frame.flvTag);
       }
-      publisher.publishVideoData(frame.flvTag.array(), frame.flvTag.size(), dts);
-      mVideoAllocator.release(frame.flvTag);
       mVideoFramesSent++;
     } else if (frame.is_audio()) {
       publisher.publishAudioData(frame.flvTag.array(), frame.flvTag.size(), dts);


### PR DESCRIPTION
## 概要
d-o-n-u-t-s/mixch-doc#2695

## 動作確認方法
- 特になし

## やったこと
- 1.8.4のマージミスを修正
- ビデオのdtsと音声のdtsに差異がありtsが作れてなかった？ので、音声のdtsを利用するように修正
- 修正前後でUI変更があった場合はスクショも貼る

|before|after|
|------|-----|
|||

## 動作確認端末
- [x] 【SYS968】Pixel3 a

## テスト
- [x] ミラーリング配信を行い、画面に変化がない状況でも視聴が続くこと

### テスト観点
- テキスト関連
   - 絵文字を入力
   - 文字数が多い場合
- ネットワーク関連
   - オフライン状態
   - 通信状態が悪い
- UI
   - ノッチあり・なし
   - ディスプレイサイズの違い
   - jやqなどでdesentが文字切れしていないか
   - タブバーに埋もれていないか
   - 画面回転
- OS
   - OSの違い
