### PR TITLE
fix:VersionCatalogの導入に伴い、mixch側のrootのextensionからkotlinVersionを参照していた箇所の削除

### DIFF
--- a/rtsp/build.gradle
+++ b/rtsp/build.gradle
@@ -18,7 +18,3 @@ android {
         }
     }
 }
-
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-}


### PR DESCRIPTION
## 概要
本PR
https://github.com/d-o-n-u-t-s/mixch-android/pull/2171