### PR TITLE
#6238 agpのバージョンを8.2.2, gradleのバージョンを8.2, buildtoolのバージョンを34.0.0に更新

### DIFF
--- a/encoder/build.gradle
+++ b/encoder/build.gradle
@@ -16,6 +16,7 @@ android {
             consumerProguardFiles 'proguard-rules.pro'
         }
     }
+    namespace = "com.pedro.encoder"
 }
 
 dependencies {

--- a/encoder/src/main/AndroidManifest.xml
+++ b/encoder/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.pedro.encoder" />
+<manifest />

--- a/rtmp/build.gradle
+++ b/rtmp/build.gradle
@@ -15,6 +15,7 @@ android {
             minifyEnabled false
         }
     }
+    namespace = "net.ossrs.rtmp"
 }
 
 dependencies {

--- a/rtmp/src/main/AndroidManifest.xml
+++ b/rtmp/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="net.ossrs.rtmp" />
+<manifest />

--- a/rtplibrary/build.gradle
+++ b/rtplibrary/build.gradle
@@ -16,6 +16,7 @@ android {
             consumerProguardFiles 'proguard-rules.pro'
         }
     }
+    namespace = "com.pedro.rtplibrary"
 }
 
 dependencies {

--- a/rtplibrary/src/main/AndroidManifest.xml
+++ b/rtplibrary/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.pedro.rtplibrary" />
+<manifest />

--- a/rtsp/build.gradle
+++ b/rtsp/build.gradle
@@ -17,4 +17,9 @@ android {
             consumerProguardFiles 'proguard-rules.pro'
         }
     }
+    namespace = "com.pedro.rtsp"
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }

--- a/rtsp/src/main/AndroidManifest.xml
+++ b/rtsp/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.pedro.rtsp" />
+<manifest />


### PR DESCRIPTION
- https://github.com/d-o-n-u-t-s/mixch-android/pull/3022

gradle8.0でnamespaceの定義はmanifestからbuild.gradleで定義するようになったので変更
gradle8.0でJava17が必要にになったので変更