### PR TITLE
#8773 Android Studio を Ladybug にするとビルドが通らなくなることがある

### DIFF
--- a/rtsp/build.gradle
+++ b/rtsp/build.gradle
@@ -22,4 +22,7 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
+    }
 }


### PR DESCRIPTION
## 概要

- d-o-n-u-t-s/mixch-doc#8773

## やったこと

- `libraries/rtmp-rtsp-stream-client-java` のbuild.gradle.ktsにて、KotlinのJvmバージョン指定を追加