### PR TITLE
#9556 repositoriesの指定をdependencyResolutionManagementに移行

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@
 buildscript {
   ext.kotlin_version = '1.4.30'
   repositories {
-    jcenter()
     google()
     mavenCentral()
   }
@@ -19,14 +18,6 @@ buildscript {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files
-  }
-}
-
-allprojects {
-  repositories {
-    jcenter()
-    google()
-    mavenCentral()
   }
 }
 


### PR DESCRIPTION
## 概要

- d-o-n-u-t-s/mixch-doc#9556
- mixch-android 側
  - https://github.com/d-o-n-u-t-s/mixch-android/pull/4326

## やったこと

<!-- やったことを箇条書きで詳細に記述する -->
<!-- この項目は必ず記述すること -->
- 各 repositories の記述を、現在標準である dependencyResolutionManagement で書くように変更。
- 上記対応を親プロジェクトでした際に、allproject による repositories 指定が邪魔なので削除する
  - 親プロジェクトに対する影響はない。